### PR TITLE
Handle wildcard content type, e.g. text/*

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -57,8 +57,9 @@ module.exports = function(MsrpSdk) {
 
     // Check if the remote endpoint will accept the message by checking its SDP
     contentType = contentType || 'text/plain';
+    // Get the wildcard type, e.g. text/*
     var canSend = session.remoteSdp.attributes['accept-types'].some(function(acceptType) {
-      return (acceptType === contentType || acceptType === '*');
+      return (acceptType === contentType || acceptType === wildcardContentType || acceptType === '*');
     });
     if (session.remoteSdp.attributes.sendonly || session.remoteSdp.attributes.inactive) {
       canSend = false;


### PR DESCRIPTION
Handle scenario where remote SDP includes a wildcard content type (e.g. text/*) in the accept-types attribute.

For instance:

o=- 3791909954 3791909954 IN IP4 172.20.38.19
s=Blink Lite 4.6.0 (MacOSX)
t=0 0
m=message 2855 TCP/MSRP *
c=IN IP4 172.20.38.19
a=path:msrp://172.20.38.19:2855/2b67624ad38d41e3e07d;tcp
a=accept-types:message/cpim text/* image/* application/im-iscomposing+xml
a=accept-wrapped-types:text/* image/* application/im-iscomposing+xml
a=setup:active
a=blink-features:history-control icon
